### PR TITLE
Migrate Eleventy to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "athomasoriginal <thomasmattacchione@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@11ty/eleventy": "0.12.1",
+    "@11ty/eleventy": "^1.0.0-beta.5",
     "@11ty/eleventy-plugin-rss": "1.1.1"
   },
   "scripts": {


### PR DESCRIPTION
## What's Up?

Eleventy is going into 1.0 status.  This PR is about adopting the 1.0 release.